### PR TITLE
Let VTK delete timers on exit.

### DIFF
--- a/fury/window.py
+++ b/fury/window.py
@@ -657,10 +657,9 @@ class ShowManager(object):
 
     def exit(self):
         """Close window and terminate interactor."""
-        if self.timers:
-            self.destroy_timers()
         self.iren.GetRenderWindow().Finalize()
         self.iren.TerminateApp()
+        self.timers.clear()
 
 
 def show(scene, title='FURY', size=(300, 300), png_magnify=1,


### PR DESCRIPTION
With this fix and the latest VTK' [release branch](https://gitlab.kitware.com/vtk/vtk/-/tree/release) (which includes the fix for the TimerEvents), all fury tests are green except for `fury/tests/test_window.py::test_order_transparent` :-/. 
Edit: this fixes https://github.com/fury-gl/fury/issues/253